### PR TITLE
refactor: 유저 프로필 이미지 업로드 비동기 처리

### DIFF
--- a/src/main/java/com/palgona/palgona/auth/presentation/LoginController.java
+++ b/src/main/java/com/palgona/palgona/auth/presentation/LoginController.java
@@ -9,6 +9,7 @@ import com.palgona.palgona.auth.dto.AuthToken;
 import com.palgona.palgona.auth.dto.response.LoginResponse;
 import com.palgona.palgona.member.dto.request.MemberCreateRequest;
 import com.palgona.palgona.auth.application.LoginService;
+import com.palgona.palgona.member.dto.request.MemberCreateRequestWithoutImage;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,7 +22,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,9 +43,12 @@ public class LoginController {
     @Operation(summary = "회원 가입 api", description = "닉네임, 프로필을 받아서 회원가입을 진행한다.")
     public ResponseEntity<Void> create(
             @AuthenticationPrincipal CustomMemberDetails member,
-            @ModelAttribute MemberCreateRequest request
+            @RequestPart MemberCreateRequestWithoutImage request,
+            @RequestPart(required = false) MultipartFile file
     ) {
-        Long memberId = loginService.signUp(member, request);
+
+        MemberCreateRequest memberCreateRequest = MemberCreateRequest.of(request, file);
+        Long memberId = loginService.signUp(member, memberCreateRequest);
 
         return ResponseEntity.created(URI.create("/members/" + memberId))
                 .build();

--- a/src/main/java/com/palgona/palgona/image/dto/ImageUploadRequest.java
+++ b/src/main/java/com/palgona/palgona/image/dto/ImageUploadRequest.java
@@ -6,4 +6,13 @@ public record ImageUploadRequest(
         MultipartFile file,
         String uploadFileName
 ) {
+    public static ImageUploadRequest of(
+            MultipartFile file,
+            String uploadFileName
+    ) {
+        return new ImageUploadRequest(
+                file,
+                uploadFileName
+        );
+    }
 }

--- a/src/main/java/com/palgona/palgona/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/palgona/palgona/member/dto/request/MemberCreateRequest.java
@@ -4,5 +4,17 @@ import org.springframework.web.multipart.MultipartFile;
 
 public record MemberCreateRequest(
         String nickName,
-        MultipartFile image) {
+        MultipartFile image
+) {
+
+    public static MemberCreateRequest of(
+            MemberCreateRequestWithoutImage request,
+            MultipartFile file
+    ) {
+        return new MemberCreateRequest(
+                request.nickName(),
+                file
+        );
+    }
+
 }

--- a/src/main/java/com/palgona/palgona/product/event/ImageUploadEvent.java
+++ b/src/main/java/com/palgona/palgona/product/event/ImageUploadEvent.java
@@ -6,4 +6,8 @@ import java.util.List;
 public record ImageUploadEvent(
         List<ImageUploadRequest> imageUploadRequests
 ) {
+
+    public static ImageUploadEvent from(List<ImageUploadRequest> imageUploadRequests) {
+        return new ImageUploadEvent(imageUploadRequests);
+    }
 }


### PR DESCRIPTION
## Issue
* resolve #4 

## Change
* 유저의 프로필 이미지 변경을 비동기로 처리한다.

## etc
* 이미지 업로드를 진행할 때, 업로드 파일 이름 생성, 이벤트 발행 부분 코드가 중복되고 있다.
* 해당 부분에 대한 모듈화가 필요할 것 같다.